### PR TITLE
Remove load argument from SortedListWithKey initialization

### DIFF
--- a/greedypacker/guillotine.py
+++ b/greedypacker/guillotine.py
@@ -53,9 +53,9 @@ class Guillotine:
 
         if x == 0 or y == 0:
             #self.freerects = [] # type: List[FreeRectangle]
-            self.freerects = SortedListWithKey(iterable=None, key=lambda x: x.area, load=1000)
+            self.freerects = SortedListWithKey(iterable=None, key=lambda x: x.area)
         else:
-            self.freerects = SortedListWithKey([FreeRectangle(self.x, self.y, 0, 0)], key=lambda x: x.area, load=1000)
+            self.freerects = SortedListWithKey([FreeRectangle(self.x, self.y, 0, 0)], key=lambda x: x.area)
         self.items = [] # type: List[Item]
         self.rotation = rotation
 

--- a/test/test_guillotine.py
+++ b/test/test_guillotine.py
@@ -41,7 +41,7 @@ class BestShortSide(BaseTestCase):
         F1 = self.freeRectangle(2, 2, 1, 0)
         ITEM = item.Item(1, 1)
 
-        self.BIN.freerects = SortedListWithKey([F0, F1], key=lambda x: x.area, load=1000)
+        self.BIN.freerects = SortedListWithKey([F0, F1], key=lambda x: x.area)
         self.BIN.insert(ITEM)
 
         with self.subTest():
@@ -66,7 +66,7 @@ class BestShortSide(BaseTestCase):
         ITEM = item.Item(1, 2)
         
         self.BIN.rotation = True
-        self.BIN.freerects = SortedListWithKey([F0], key=lambda x: x.area, load=1000)
+        self.BIN.freerects = SortedListWithKey([F0], key=lambda x: x.area)
         self.BIN.insert(ITEM)
 
         with self.subTest():
@@ -113,7 +113,7 @@ class BestLongSide(BaseTestCase):
         F1 = self.freeRectangle(2, 1, 1, 0)
         ITEM = item.Item(1, 1)
 
-        self.BIN.freerects = SortedListWithKey([F0, F1], key=lambda x: x.area, load=1000)
+        self.BIN.freerects = SortedListWithKey([F0, F1], key=lambda x: x.area)
         self.BIN.insert(ITEM)
 
         with self.subTest():
@@ -186,8 +186,8 @@ class BestAreaFit(BaseTestCase):
         F0 = self.freeRectangle(2, 2, 0, 0)
         F1 = self.freeRectangle(3, 3, 2, 0)
         ITEM = item.Item(1, 1)
-        
-        self.BIN.freerects = SortedListWithKey([F0, F1], key=lambda x: x.area, load=1000)
+
+        self.BIN.freerects = SortedListWithKey([F0, F1], key=lambda x: x.area)
         self.BIN.insert(ITEM)
         with self.subTest():
             correct = [self.freeRectangle(2, 1, 0, 1),
@@ -261,7 +261,7 @@ class WorstLongSide(BaseTestCase):
         F1 = self.freeRectangle(2, 1, 1, 0)
         ITEM = item.Item(1, 1)
 
-        self.BIN.freerects = SortedListWithKey([F0, F1], key=lambda x: x.area, load=1000)
+        self.BIN.freerects = SortedListWithKey([F0, F1], key=lambda x: x.area)
         self.BIN.insert(ITEM)
 
         with self.subTest():
@@ -335,7 +335,7 @@ class WorstShortSide(BaseTestCase):
         F1 = self.freeRectangle(2, 2, 1, 0)
         ITEM = item.Item(1, 1)
 
-        self.BIN.freerects = SortedListWithKey([F0, F1], key=lambda x: x.area, load=1000)
+        self.BIN.freerects = SortedListWithKey([F0, F1], key=lambda x: x.area)
         self.BIN.insert(ITEM)
 
         with self.subTest():
@@ -409,8 +409,8 @@ class WorstAreaFit(BaseTestCase):
         F0 = self.freeRectangle(2, 2, 0, 0)
         F1 = self.freeRectangle(3, 3, 2, 0)
         ITEM = item.Item(1, 1)
-        
-        self.BIN.freerects = SortedListWithKey([F0, F1], key=lambda x: x.area, load=1000)
+
+        self.BIN.freerects = SortedListWithKey([F0, F1], key=lambda x: x.area)
         self.BIN.insert(ITEM)
         with self.subTest():
             correct = [self.freeRectangle(2, 2, 0, 0),

--- a/test/test_skyline.py
+++ b/test/test_skyline.py
@@ -109,7 +109,7 @@ class Methods(BaseTestCase):
         S1 = skyline.SkylineSegment(0, 1, 2)
         S2 = skyline.SkylineSegment(2, 0, 6)
         self.S.skyline.pop()
-        self.S.skyline.extend([S1, S2])
+        self.S.skyline.update([S1, S2])
         self.assertEqual(self.S._check_fit(I.width, I.height, 0), (True, 1))
 
 
@@ -121,7 +121,7 @@ class Methods(BaseTestCase):
         S1 = skyline.SkylineSegment(0, 0, 1)
         S2 = skyline.SkylineSegment(1, 3, 7)
         self.S.skyline.pop()
-        self.S.skyline.extend([S1, S2])
+        self.S.skyline.update([S1, S2])
         self.assertEqual(self.S._check_fit(I.width, I.height, 1), (False, None))
 
     


### PR DESCRIPTION
greedypacker does not require a specific version of sortedcontainers
in its setup.py (it does in the requirements.txt).
More recent versions of sortedcontainers have gotten rid of the `load`
parameter.
cf. https://github.com/grantjenks/python-sortedcontainers/commit/c53d6c4f736c08646c4588800b8bcbb78a9bc68d

Removing the load argument allows the Guillotine algorithm to function
with both recent and old versions of sortedcontainers.

This should fix #2, although there are additional issues with more recent
versions of sortedcontainers in other parts.
Another option would be to strictly rely on a specific version of 
sortedcontainers in setup.py.